### PR TITLE
fix issue when only a single child node is present

### DIFF
--- a/lib/reactive-ruby/component.rb
+++ b/lib/reactive-ruby/component.rb
@@ -28,7 +28,7 @@ module React
         end unless method_defined? :render
 
         def children
-          nodes = `#{@native}.props.children` || []
+          nodes = [`#{@native}.props.children`].flatten
           class << nodes
             include Enumerable
 


### PR DESCRIPTION
When passing children props, `#{@native}.props.children` returns a single react node, not an array containing a node. Wrapping in an array ensures `class << nodes` doesn't blow up trying to open the eigenclass of a native object.

Now we can do this:

``` ruby
def render
  Parent() do
    "this is a single child node".span
  end
end
```
